### PR TITLE
Label spaces and fetch by label

### DIFF
--- a/scripts/pgsql_functions.tmpl.sql
+++ b/scripts/pgsql_functions.tmpl.sql
@@ -32,6 +32,7 @@ BEGIN
         FOR _ IN 1..num_spaces_per_org LOOP
             space_guid := gen_random_uuid();
             INSERT INTO spaces (guid, name, organization_id) VALUES (space_guid, space_name_prefix || space_guid, org_id);
+            INSERT INTO space_labels (guid, key_name, resource_guid) VALUES (space_guid, '{{.Prefix}}', space_guid);
         END LOOP;
     END LOOP;
 END;

--- a/security_groups/v1/security_groups_test.go
+++ b/security_groups/v1/security_groups_test.go
@@ -33,7 +33,7 @@ var _ = Describe("security groups", func() {
 		}, testConfig.Samples)
 
 		Measure(fmt.Sprintf("as admin with space filter containing %d spaces", testConfig.LargeElementsFilter), func(b Benchmarker) {
-			spaceGUIDs := helpers.GetGUIDs(testSetup.AdminUserContext(), testConfig, fmt.Sprintf("/v3/spaces?per_page=%d", testConfig.LargeElementsFilter))
+			spaceGUIDs := helpers.GetGUIDs(testSetup.AdminUserContext(), testConfig, fmt.Sprintf("/v3/spaces?per_page=%d&label_selector=%s", testConfig.LargeElementsFilter, testConfig.TestResourcePrefix))
 			Expect(spaceGUIDs).NotTo(BeNil())
 			Expect(len(spaceGUIDs)).To(Equal(testConfig.LargeElementsFilter))
 			spaceGUIDs = helpers.Shuffle(spaceGUIDs)


### PR DESCRIPTION
There are some default spaces created by the CATs setup. These spaces
get a randomised GUID which is the default sorting field which means
sometimes the first 100 results for /v3/spaces includes a non-perf space
and then the GetGUIDs functions filters this space out. This causes some
assertions that 100 results were returned to fail (in the
security_groups test)